### PR TITLE
Fix PHP 7.4.0 Notice - Array-style access of non-arrays

### DIFF
--- a/system/class/Page/PageManager.php
+++ b/system/class/Page/PageManager.php
@@ -99,7 +99,7 @@ abstract class PageManager
         if (_env === Core::ENV_WEB) {
             global $_index;
 
-            if ($_index['is_page']) {
+            if ($_index['is_page'] && $_index['is_found']) {
                 $id = $_index['id'];
                 $data = $GLOBALS['_page'];
             }


### PR DESCRIPTION
`PHP Notice: Trying to access array offset on value of type bool in ...\project_name\system\class\Template.php:512` [Template.php:512](https://github.com/sunlight-cms/sunlight-cms-8/blob/master/system/class/Template.php#L512)

In the `index.prepare` event, the [PageManager::getActive()](https://github.com/sunlight-cms/sunlight-cms-8/blob/master/system/class/Page/PageManager.php#L94) method does not return `array(null, null)`, but `array(null, false)` because the non-existent [$GLOBALS ['_page']](https://github.com/sunlight-cms/sunlight-cms-8/blob/master/system/class/Page/PageManager.php#L104) equals `false`