### PR TITLE
Move the Form::render() param 'multipart' after the event

### DIFF
--- a/system/class/Util/Form.php
+++ b/system/class/Util/Form.php
@@ -384,15 +384,16 @@ abstract class Form
             'form_prepend' => '',
             'form_append' => '',
         );
-        if ($options['multipart']) {
-            $options['enctype'] = 'multipart/form-data';
-        }
-
+        
         // extend
         $extend_buffer = Extend::buffer('form.output', array(
             'options' => &$options,
             'rows' => &$rows,
         ));
+        
+        if ($options['multipart']) {
+            $options['enctype'] = 'multipart/form-data';
+        }
 
         if ($extend_buffer !== '') {
             // vykresleni pretizeno


### PR DESCRIPTION
Allows events to affect the value of multipart by setting `true`/`false`, instead of overloading in the enctype parameter. This option is there, so why make it more complicated.

`$args['options']['multipart'] = true;` instead of `$args['options']['enctype'] = 'multipart/form-data';`